### PR TITLE
Don't use `jackson-databind-nullable` to fix serialization problems with `Jackson` default configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = { extends: ['@fingerprintjs/commit-lint-dx-team'] };

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 jackson = "2.17.2"
-jackson-databind-nullable = "0.2.6"
 jakarta-annotation-api = "2.0.0"
 jersey = "3.1.7"
 junit = "5.10.2"
@@ -12,7 +11,6 @@ swagger-annotations = "2.2.22"
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
-jackson-databind-nullable = { module = "org.openapitools:jackson-databind-nullable", version.ref = "jackson-databind-nullable" }
 jackson-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation-api" }
 jersey-apache-connector = { module = "org.glassfish.jersey.connectors:jersey-apache-connector", version.ref = "jersey" }

--- a/sdk/sdk.gradle.kts
+++ b/sdk/sdk.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     api(libs.jackson.core)
     api(libs.jackson.annotations)
     api(libs.jackson.databind)
-    api(libs.jackson.databind.nullable)
     api(libs.jackson.jsr310)
     api(libs.jakarta.annotation.api)
     testImplementation(libs.junit.jupiter.api)
@@ -68,6 +67,7 @@ openApiGenerate {
     gitRepoId.set("fingerprint-pro-server-api-java-sdk")
     gitUserId.set("fingerprintjs")
     configOptions.put("hideGenerationTimestamp", "true")
+    configOptions.put("openApiNullable", "false")
 }
 
 tasks.register("removeDocs") {

--- a/sdk/src/main/java/com/fingerprint/model/RawDeviceAttributesResultValue.java
+++ b/sdk/src/main/java/com/fingerprint/model/RawDeviceAttributesResultValue.java
@@ -8,10 +8,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fingerprint.model.Error;
 import java.util.Arrays;
-import org.openapitools.jackson.nullable.JsonNullable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.openapitools.jackson.nullable.JsonNullable;
-import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fingerprint.sdk.JSON;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,7 +28,7 @@ public class RawDeviceAttributesResultValue {
   private Error error;
 
   public static final String JSON_PROPERTY_VALUE = "value";
-  private JsonNullable<Object> value = JsonNullable.<Object>of(null);
+  private Object value = null;
 
   public RawDeviceAttributesResultValue() {
   }
@@ -64,7 +60,7 @@ public class RawDeviceAttributesResultValue {
 
 
   public RawDeviceAttributesResultValue value(Object value) {
-    this.value = JsonNullable.<Object>of(value);
+    this.value = value;
     return this;
   }
 
@@ -74,26 +70,18 @@ public class RawDeviceAttributesResultValue {
   **/
   @jakarta.annotation.Nullable
   @Schema(description = "")
-  @JsonIgnore
-
-  public Object getValue() {
-        return value.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<Object> getValue_JsonNullable() {
+  public Object getValue() {
     return value;
   }
-  
-  @JsonProperty(JSON_PROPERTY_VALUE)
-  public void setValue_JsonNullable(JsonNullable<Object> value) {
-    this.value = value;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_VALUE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setValue(Object value) {
-    this.value = JsonNullable.<Object>of(value);
+    this.value = value;
   }
 
 
@@ -110,23 +98,12 @@ public class RawDeviceAttributesResultValue {
     }
     RawDeviceAttributesResultValue rawDeviceAttributesResultValue = (RawDeviceAttributesResultValue) o;
     return Objects.equals(this.error, rawDeviceAttributesResultValue.error) &&
-        equalsNullable(this.value, rawDeviceAttributesResultValue.value);
-  }
-
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+        Objects.equals(this.value, rawDeviceAttributesResultValue.value);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(error, hashCodeNullable(value));
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+    return Objects.hash(error, value);
   }
 
   @Override

--- a/sdk/src/main/java/com/fingerprint/sdk/JSON.java
+++ b/sdk/src/main/java/com/fingerprint/sdk/JSON.java
@@ -3,7 +3,6 @@ package com.fingerprint.sdk;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fingerprint.model.*;
 
@@ -30,8 +29,6 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.setDateFormat(new RFC3339DateFormat());
     mapper.registerModule(new JavaTimeModule());
-    JsonNullableModule jnm = new JsonNullableModule();
-    mapper.registerModule(jnm);
   }
 
   /**

--- a/sdk/src/test/java/com/fingerprint/SerializationTest.java
+++ b/sdk/src/test/java/com/fingerprint/SerializationTest.java
@@ -1,0 +1,56 @@
+package com.fingerprint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fingerprint.model.EventResponse;
+import com.fingerprint.model.RawDeviceAttributesResultValue;
+import com.fingerprint.model.SignalResponseRawDeviceAttributes;
+import com.fingerprint.sdk.ApiException;
+import com.fingerprint.sdk.JSON;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SerializationTest {
+
+    private InputStream getFileAsIOStream(final String fileName) {
+        InputStream ioStream = this.getClass()
+                .getClassLoader()
+                .getResourceAsStream(fileName);
+
+        if (ioStream == null) {
+            throw new IllegalArgumentException(fileName + " is not found");
+        }
+        return ioStream;
+    }
+
+    private static ObjectMapper getMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+//        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        return mapper;
+    }
+
+    @Test
+    public void serializeRawDeviceAttributesTest() throws IOException {
+        ObjectMapper sdkObjectMapper = JSON.getDefault().getMapper();
+        EventResponse eventResponse = sdkObjectMapper.readValue(getFileAsIOStream("mocks/get_event_200.json"), EventResponse.class);
+
+        SignalResponseRawDeviceAttributes signalResponseRawDeviceAttributes = eventResponse.getProducts().getRawDeviceAttributes();
+        String sdkResult = sdkObjectMapper.writeValueAsString(signalResponseRawDeviceAttributes);
+
+        ObjectMapper springLikeObjectMapper = getMapper();
+        String springResult = springLikeObjectMapper.writeValueAsString(signalResponseRawDeviceAttributes);
+
+        assertTrue(sdkResult.contains("\"architecture\":{\"value\":127}"));
+        assertTrue(springResult.contains("\"architecture\":{\"error\":null,\"value\":127}"));
+    }
+}

--- a/sdk/src/test/java/com/fingerprint/api/FingerprintApiTest.java
+++ b/sdk/src/test/java/com/fingerprint/api/FingerprintApiTest.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -69,8 +68,6 @@ public class FingerprintApiTest {
         ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        JsonNullableModule jnm = new JsonNullableModule();
-        mapper.registerModule(jnm);
         return mapper;
     }
 
@@ -263,8 +260,6 @@ public class FingerprintApiTest {
     public void webhookTest() throws Exception {
         ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        JsonNullableModule jnm = new JsonNullableModule();
-        mapper.registerModule(jnm);
 
         WebhookVisit visit =  mapper.readValue(getFileAsIOStream("mocks/webhook.json"), WebhookVisit.class);
 


### PR DESCRIPTION
In case Fingerprint Pro Server API Java SDK is used with Spring Boot without additional configuration for Jackson, `RawDeviceAttributes` values could be lost in case of serialization.

Solution - remove JsonNullable from the project.