### PR TITLE
Exit pre-release mode for releasing `7.5.0`

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "develop",
   "initialVersions": {
     "fingerprint-pro-server-api-java-sdk": "7.4.0"


### PR DESCRIPTION
This PR exits changesets prerelease mode. Since it will be pushed to the `main`, it will trigger both `changesets version` and `changesets publish`. The changeset files are not deleted in this PR because they will be removed automatically by the `changesets version` command.