### PR TITLE
Add @erayaydin to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @orkuncakilkaya @ilfa @necipallef
+* @orkuncakilkaya @ilfa @necipallef @erayaydin


### PR DESCRIPTION
This PR adds @erayaydin to the `CODEOWNERS` file to include them in future review requests directly.