### PR TITLE
Drop visitorId check and refactor functional tests

### DIFF
--- a/examples/examples.gradle.kts
+++ b/examples/examples.gradle.kts
@@ -47,6 +47,7 @@ tasks.register<JavaExec>("runFunctionalTests") {
     mainClass = "com.fingerprint.example.FunctionalTests"
     classpath = sourceSets["main"].runtimeClasspath
     environment(loadEnv())
+    jvmArgs("-ea")
 }
 
 tasks.named("runFunctionalTests") {


### PR DESCRIPTION
Made the functional test script simpler. We no longer compare `visitorId` between recent and oldest events. 

## ✏️  What Changed?

- Compare old vs new events by `requestId` only (removed `visitorId` check) so repeated visitors don't fail the check.
- Validate `FPJS_API_SECRET` env variable at startup. Fail fast if missing.
- Normalize `FPJS_API_REGION` env reading.
- Drop unused `ApiClient` import.
- Simplify api client building.
- Replace global `FPJS_*` with local variables.
- Add null-safety assertions.
- Small readability tweaks.